### PR TITLE
GET groupsのレスポンスJSONのキーが大文字になってしまっている

### DIFF
--- a/pkg/interface/response/group.go
+++ b/pkg/interface/response/group.go
@@ -3,5 +3,5 @@ package response
 import "github.com/datti-api/pkg/domain/model"
 
 type Groups struct {
-	Groups []*model.Group
+	Groups []*model.Group `json:"groups"`
 }


### PR DESCRIPTION
以下の画像の通り、レスポンスのJSONをgropusに修正しました。
![スクリーンショット 2024-04-22 22 44 41](https://github.com/Haebeal/datti-api/assets/101637909/d5a22a5a-2c31-4bc0-b539-5abbc522c0ce)
closed #126 