### PR TITLE
口座情報をユーザー情報として扱えるようにして欲しい

### DIFF
--- a/openapi/endpoints/users.tsp
+++ b/openapi/endpoints/users.tsp
@@ -88,17 +88,37 @@ model User {
    * 画像URL
    */
   photoUrl: string;
+
+  /**
+   * 講座情報
+   */
+  bank: Bank;
 }
 
 model UserList {
-  users: User[];
-}
+  users: {
+    /**
+     * ユーザーID
+     */
+    @minLength(28)
+    @maxLength(28)
+    uid: string;
 
-model UserGetRequest {
-  /**
-   * メールアドレス
-   */
-  email: string;
+    /**
+     * ユーザー名
+     */
+    name: string;
+
+    /**
+     * メールアドレス
+     */
+    email: string;
+
+    /**
+     * 画像URL
+     */
+    photoUrl: string;
+  }[];
 }
 
 model UserUpdateRequest{
@@ -111,4 +131,25 @@ model UserUpdateRequest{
    * 画像URL
    */
   photoUrl: string;
+
+  /**
+   * 金融機関コード
+   */
+  @minLength(4)
+  @maxLength(4)
+  bankCode: string;
+
+  /**
+   * 支店番号
+   */
+  @minLength(3)
+  @maxLength(3)
+  branchCode: string;
+  
+  /**
+   * 口座番号
+   */
+  @minLength(7)
+  @maxLength(7)
+  accountCode: string;
 }

--- a/pkg/interface/api/handler/user.go
+++ b/pkg/interface/api/handler/user.go
@@ -24,11 +24,11 @@ type userHandler struct {
 
 // HandleGetByUidWithPahtParam implements UserHandler.
 func (u *userHandler) HandleGetByUidWithPahtParam(c echo.Context) error {
-	res := new(response.User)
+	res := new(response.UserWithBankAccount)
 	errResponse := new(response.Error)
 	uid := c.Param("uid")
 
-	user, err := u.useCase.GetUserByUid(c.Request().Context(), uid)
+	user, bank, err := u.useCase.GetUserByUid(c.Request().Context(), uid)
 	if err != nil {
 		errResponse.Error = err.Error()
 		return c.JSON(http.StatusInternalServerError, errResponse)
@@ -37,6 +37,9 @@ func (u *userHandler) HandleGetByUidWithPahtParam(c echo.Context) error {
 		res.Name = user.Name
 		res.Email = user.Email
 		res.PhotoUrl = user.PhotoUrl
+		res.Bank.BankCode = bank.BankCode
+		res.Bank.BranchCode = bank.BranchCode
+		res.Bank.AccountCode = bank.AccountCode
 		return c.JSON(http.StatusOK, res)
 	}
 }
@@ -59,11 +62,11 @@ func (u *userHandler) HandleGetByEmail(c echo.Context) error {
 
 // HandleGetByUid implements UserHandler.
 func (u *userHandler) HandleGetByUid(c echo.Context) error {
-	res := new(response.User)
+	res := new(response.UserWithBankAccount)
 	errResponse := new(response.Error)
 	uid := c.Get("uid").(string)
 
-	user, err := u.useCase.GetUserByUid(c.Request().Context(), uid)
+	user, bank, err := u.useCase.GetUserByUid(c.Request().Context(), uid)
 	if err != nil {
 		errResponse.Error = err.Error()
 		return c.JSON(http.StatusInternalServerError, errResponse)
@@ -72,6 +75,9 @@ func (u *userHandler) HandleGetByUid(c echo.Context) error {
 		res.Name = user.Name
 		res.Email = user.Email
 		res.PhotoUrl = user.PhotoUrl
+		res.Bank.BankCode = bank.BankCode
+		res.Bank.BranchCode = bank.BranchCode
+		res.Bank.AccountCode = bank.AccountCode
 		return c.JSON(http.StatusOK, res)
 	}
 }
@@ -93,7 +99,7 @@ func (u *userHandler) HandleGetUsers(c echo.Context) error {
 // HandleUpdate implements UserHandler.
 func (u *userHandler) HandleUpdate(c echo.Context) error {
 	req := new(request.UpdateUserRequest)
-	res := new(response.User)
+	res := new(response.UserWithBankAccount)
 	errRes := new(response.Error)
 	uid := c.Get("uid").(string)
 
@@ -103,7 +109,7 @@ func (u *userHandler) HandleUpdate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, errRes)
 	}
 
-	user, err := u.useCase.UpdateUser(c.Request().Context(), uid, req.Name, req.Url)
+	user, bank, err := u.useCase.UpdateUser(c.Request().Context(), uid, req.Name, req.Url, req.BankCode, req.BranchCode, req.AccountCode)
 	if err != nil {
 		errRes.Error = err.Error()
 		return c.JSON(http.StatusInternalServerError, errRes)
@@ -112,6 +118,9 @@ func (u *userHandler) HandleUpdate(c echo.Context) error {
 		res.Name = user.Name
 		res.Email = user.Email
 		res.PhotoUrl = user.PhotoUrl
+		res.Bank.BankCode = bank.BankCode
+		res.Bank.BranchCode = bank.BranchCode
+		res.Bank.AccountCode = bank.AccountCode
 		return c.JSON(http.StatusOK, res)
 	}
 }

--- a/pkg/interface/api/server/server.go
+++ b/pkg/interface/api/server/server.go
@@ -28,13 +28,13 @@ func Sever(dsn string, hostName string, dbInit bool) {
 	// 依存性の解決
 	transaction := repositoryimpl.NewTransaction(dbClient.Client)
 
-	userRepository := repositoryimpl.NewProfileRepoImpl(tenantClient)
-	userUseCase := usecase.NewUserUseCase(userRepository)
-	userHandler := handler.NewUserHandler(userUseCase)
-
 	bankAccountRepository := repositoryimpl.NewBankAccountRepository(dbClient)
 	bankAccountUseCase := usecase.NewBankAccountUseCase(bankAccountRepository, transaction)
 	bankAccountHandler := handler.NewBankAccountHandler(bankAccountUseCase)
+
+	userRepository := repositoryimpl.NewProfileRepoImpl(tenantClient)
+	userUseCase := usecase.NewUserUseCase(userRepository, bankAccountRepository)
+	userHandler := handler.NewUserHandler(userUseCase)
 
 	friendRepository := repositoryimpl.NewFriendRepository(dbClient)
 	friendUseCase := usecase.NewFriendUseCase(friendRepository, userRepository, transaction)

--- a/pkg/interface/request/user.go
+++ b/pkg/interface/request/user.go
@@ -5,8 +5,11 @@ type UserGetRequest struct {
 }
 
 type UpdateUserRequest struct {
-	Name string `json:"name"`
-	Url  string `json:"photoUrl"`
+	Name        string `json:"name"`
+	Url         string `json:"photoUrl"`
+	BankCode    string `json:"bankCode"`
+	BranchCode  string `json:"branchCode"`
+	AccountCode string `json:"accountCode"`
 }
 
 type GetUserByEmailRequest struct {

--- a/pkg/interface/response/user.go
+++ b/pkg/interface/response/user.go
@@ -2,6 +2,18 @@ package response
 
 import "github.com/datti-api/pkg/domain/model"
 
+type UserWithBankAccount struct {
+	UID      string `json:"uid"`
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	PhotoUrl string `json:"photoUrl"`
+	Bank     struct {
+		AccountCode string `json:"accountCode"`
+		BankCode    string `json:"bankCode"`
+		BranchCode  string `json:"branchCode"`
+	}
+}
+
 type User struct {
 	UID      string `json:"uid"`
 	Name     string `json:"name"`


### PR DESCRIPTION
get・put:  /users/meと/users/{uid}に対するレスポンスにbankフィールドが追加されました。
口座情報が登録されていない場合は以下の画像の様に""が設定された状態で返されます。
![スクリーンショット 2024-04-23 18 16 34](https://github.com/Haebeal/datti-api/assets/101637909/e895672a-6e55-4355-8180-e0516e94e1a5)
