### PR TITLE
振込先設定の取得のレスポンスと更新のリクエストを同じ構造にして欲しい

### DIFF
--- a/openapi/endpoints/users.tsp
+++ b/openapi/endpoints/users.tsp
@@ -110,5 +110,8 @@ model UserUpdateRequest{
    */
   photoUrl: string;
 
-  ...Bank
+  /**
+   * 口座情報
+   */
+  bank: Bank;
 }

--- a/pkg/interface/request/user.go
+++ b/pkg/interface/request/user.go
@@ -5,11 +5,13 @@ type UserGetRequest struct {
 }
 
 type UpdateUserRequest struct {
-	Name        string `json:"name"`
-	Url         string `json:"photoUrl"`
-	BankCode    string `json:"bankCode"`
-	BranchCode  string `json:"branchCode"`
-	AccountCode string `json:"accountCode"`
+	Name string `json:"name"`
+	Url  string `json:"photoUrl"`
+	Bank struct {
+		BankCode    string `json:"bankCode"`
+		BranchCode  string `json:"branchCode"`
+		AccountCode string `json:"accountCode"`
+	} `json:"bank"`
 }
 
 type GetUserByEmailRequest struct {

--- a/pkg/interface/response/user.go
+++ b/pkg/interface/response/user.go
@@ -11,7 +11,7 @@ type UserWithBankAccount struct {
 		AccountCode string `json:"accountCode"`
 		BankCode    string `json:"bankCode"`
 		BranchCode  string `json:"branchCode"`
-	}
+	} `json:"bank"`
 }
 
 type User struct {
@@ -22,5 +22,5 @@ type User struct {
 }
 
 type Users struct {
-	Users []*model.User `json:"users"`
+	Users []*model.User `json:"usrs"`
 }


### PR DESCRIPTION
user構造体の中にbank構造体としてネストする仕様に統一しました
以下は1例です

・リクエストボディ
{
  "name": "string",
  "photoUrl": "string",
  "bank": {
    "bankCode": "stri",
    "branchCode": "str",
    "accountCode": "strings"
  }
}

・レスポンスボディ
`{
  "uid": "stringstringstringstringstri",
  "name": "string",
  "email": "string",
  "photoUrl": "string",
  "bank": {
    "bankCode": "stri",
    "branchCode": "str",
    "accountCode": "strings"
  },
  "createdAt": "2024-05-11T10:05:54.215Z",
  "updatedAt": "2024-05-11T10:05:54.215Z",
  "deletedAt": "2024-05-11T10:05:54.215Z"
}`