### PR TITLE
issue#135,#136の修正

### DIFF
--- a/pkg/domain/model/event.go
+++ b/pkg/domain/model/event.go
@@ -3,12 +3,12 @@ package model
 import "time"
 
 type Event struct {
-	ID        string     `bun:"id"`
-	Name      string     `bun:"name"`
-	CreatedBy string     `bun:"created_by"`
-	GroupId   string     `bun:"group_id"`
-	EventedAt time.Time  `bun:"evented_at, nullzero,notnull"`
-	CreatedAt time.Time  `bun:"created_at,nullzero,notnull,default:current_timestamp"`
-	UpdatedAt time.Time  `bun:"updated_at,nullzero,notnull,default:current_timestamp"`
-	DeletedAt *time.Time `bun:"deleted_at,soft_delete"`
+	ID        string     `bun:"id" json:"id"`
+	Name      string     `bun:"name" json:"name"`
+	CreatedBy string     `bun:"created_by" json:"created_by"`
+	GroupId   string     `bun:"group_id" json:"Group_id"`
+	EventedAt time.Time  `bun:"evented_at, nullzero,notnull" json:"evented_at"`
+	CreatedAt time.Time  `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
+	UpdatedAt time.Time  `bun:"updated_at,nullzero,notnull,default:current_timestamp" json:"updated_at"`
+	DeletedAt *time.Time `bun:"deleted_at,soft_delete" json:"deleted_at"`
 }

--- a/pkg/domain/model/event.go
+++ b/pkg/domain/model/event.go
@@ -6,7 +6,7 @@ type Event struct {
 	ID        string     `bun:"id" json:"id"`
 	Name      string     `bun:"name" json:"name"`
 	CreatedBy string     `bun:"created_by" json:"created_by"`
-	GroupId   string     `bun:"group_id" json:"Group_id"`
+	GroupId   string     `bun:"group_id" json:"group_id"`
 	EventedAt time.Time  `bun:"evented_at, nullzero,notnull" json:"evented_at"`
 	CreatedAt time.Time  `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
 	UpdatedAt time.Time  `bun:"updated_at,nullzero,notnull,default:current_timestamp" json:"updated_at"`

--- a/pkg/interface/api/handler/event.go
+++ b/pkg/interface/api/handler/event.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 
+	"github.com/datti-api/pkg/domain/model"
 	"github.com/datti-api/pkg/interface/request"
 	"github.com/datti-api/pkg/interface/response"
 	"github.com/datti-api/pkg/usecase"
@@ -77,8 +78,13 @@ func (e *eventHandler) HandleGetById(c echo.Context) error {
 		errResponse.Error = err.Error()
 		return c.JSON(http.StatusInternalServerError, errResponse)
 	} else {
-		res.Events = events
-		return c.JSON(http.StatusOK, res)
+		if events == nil {
+			res.Events = make([]*model.Event, 0)
+			return c.JSON(http.StatusOK, res)
+		} else {
+			res.Events = events
+			return c.JSON(http.StatusOK, res)
+		}
 	}
 }
 


### PR DESCRIPTION
GET /groups/{id}/events のレスポンスのキー値が大文字になってしまう問題と、イベント情報が存在しない場合にnilが返される不具合を修正しまいした。
インベント情報が存在しない場合は以下のような配列が返されます
`{
    "events": []
}`

close #135 
close #130 