### PR TITLE
GET /groups/{id}/members を実装して欲しい

### DIFF
--- a/openapi/endpoints/group.tsp
+++ b/openapi/endpoints/group.tsp
@@ -32,6 +32,17 @@ namespace Groups {
   | Utils.Error.InternalServerError;
 
   /**
+   * グループに対するメンバー情報の取得
+   */
+  @route("{groupId}/members")
+  @summary("グループに対するメンバー情報の取得")
+  @get
+  op getGroupMembers(@path groupId: string):
+  | GroupMembers
+  | Utils.Error.UnauthorizedError
+  | Utils.Error.InternalServerError;
+
+  /**
    * グループに対するメンバーの追加
    */
   @route("{groupId}/members")
@@ -93,7 +104,9 @@ model GroupResponse {
    * グループ名
    */
   name: string;
+}
 
+model GroupMembers {
   /**
    * ユーザー情報
    */

--- a/openapi/endpoints/group.tsp
+++ b/openapi/endpoints/group.tsp
@@ -110,7 +110,7 @@ model GroupMembers {
   /**
    * ユーザー情報
    */
-  users: User[];
+  members: User[];
 }
 
 model GroupUpdateRequest {

--- a/pkg/domain/model/group.go
+++ b/pkg/domain/model/group.go
@@ -1,6 +1,11 @@
 package model
 
+import "time"
+
 type Group struct {
-	ID   string `bun:"id,pk" json:"id"`
-	Name string `bun:"name" json:"name"`
+	ID        string     `bun:"id,pk" json:"id"`
+	Name      string     `bun:"name" json:"name"`
+	CreatedAt time.Time  `bun:"created_at,nullzero,notnull,default:current_timestamp"`
+	UpdatedAt time.Time  `bun:"updated_at,nullzero,notnull,default:current_timestamp"`
+	DeletedAt *time.Time `bun:"deleted_at,soft_delete"`
 }

--- a/pkg/interface/api/handler/group.go
+++ b/pkg/interface/api/handler/group.go
@@ -14,6 +14,7 @@ type GroupHandler interface {
 	HandleGet(c echo.Context) error
 	HandleCreate(c echo.Context) error
 	HandleGetById(c echo.Context) error
+	HandleGetMembers(c echo.Context) error
 	HandleUpdate(c echo.Context) error
 	HandleRegisterd(c echo.Context) error
 }
@@ -69,20 +70,28 @@ func (g *groupHandler) HandleGetById(c echo.Context) error {
 	errResponse := new(response.Error)
 	id := c.Param("id")
 
-	group, members, err := g.useCase.GetGroupById(c.Request().Context(), id)
+	group, err := g.useCase.GetGroupById(c.Request().Context(), id)
 	if err != nil {
 		errResponse.Error = err.Error()
 		return c.JSON(http.StatusInternalServerError, errResponse)
 	} else {
-		return c.JSON(http.StatusOK, struct {
-			ID    string        `json:"id"`
-			Name  string        `json:"name"`
-			Users []*model.User `json:"users"`
-		}{
-			ID:    group.ID,
-			Name:  group.Name,
-			Users: members,
-		})
+		return c.JSON(http.StatusOK, group)
+	}
+}
+
+// HandleGetMembers implements GroupHandler.
+func (g *groupHandler) HandleGetMembers(c echo.Context) error {
+	errResponse := new(response.Error)
+	res := new(response.Members)
+	id := c.Param("groupId")
+
+	members, err := g.useCase.GetMembers(c.Request().Context(), id)
+	if err != nil {
+		errResponse.Error = err.Error()
+		return c.JSON(http.StatusInternalServerError, errResponse)
+	} else {
+		res.Members = members
+		return c.JSON(http.StatusOK, res)
 	}
 }
 

--- a/pkg/interface/api/server/server.go
+++ b/pkg/interface/api/server/server.go
@@ -76,11 +76,12 @@ func Sever(dsn string, hostName string, dbInit bool) {
 	r.GET("/friends/requests", friendHandler.HandleGetApplyings) //フレンド申請中のユーザー
 	r.DELETE("/friends/:uid", friendHandler.HandleDelete)        //フレンド登録の解除
 
-	r.GET("/groups", groupHandler.HandleGet)                    //所属グループ一覧の取得
-	r.GET("/groups/:id", groupHandler.HandleGetById)            //グループ情報の取得
-	r.POST("/groups", groupHandler.HandleCreate)                //グループの作成
-	r.PUT("/groups/:id", groupHandler.HandleUpdate)             //グループ情報の更新
-	r.POST("/groups/:id/members", groupHandler.HandleRegisterd) //グループに対するメンバーの追加
+	r.GET("/groups", groupHandler.HandleGet)                         //所属グループ一覧の取得
+	r.GET("/groups/:id", groupHandler.HandleGetById)                 //グループ情報の取得
+	r.POST("/groups", groupHandler.HandleCreate)                     //グループの作成
+	r.PUT("/groups/:id", groupHandler.HandleUpdate)                  //グループ情報の更新
+	r.GET("/groups/:groupId/members", groupHandler.HandleGetMembers) //グループに対するメンバー情報の取得
+	r.POST("/groups/:id/members", groupHandler.HandleRegisterd)      //グループに対するメンバーの追加
 
 	r.GET("/groups/:gid/events", eventHandler.HandleGetById)
 	r.GET("/groups/:gid/events/:id", eventHandler.HandleGet)

--- a/pkg/interface/response/group.go
+++ b/pkg/interface/response/group.go
@@ -5,3 +5,7 @@ import "github.com/datti-api/pkg/domain/model"
 type Groups struct {
 	Groups []*model.Group `json:"groups"`
 }
+
+type Members struct {
+	Members []*model.User `json:"members"`
+}

--- a/pkg/usecase/group.go
+++ b/pkg/usecase/group.go
@@ -10,7 +10,8 @@ import (
 type GroupUseCase interface {
 	GetGroups(c context.Context, uid string) ([]*model.Group, error)
 	CreateGroup(c context.Context, name string, owner string, members []string) (*model.Group, []*model.User, error)
-	GetGroupById(c context.Context, id string) (*model.Group, []*model.User, error)
+	GetGroupById(c context.Context, id string) (*model.Group, error)
+	GetMembers(c context.Context, id string) ([]*model.User, error)
 	UpdateGroup(c context.Context, id string, name string) (*model.Group, []*model.User, error)
 	RegisterdMembers(c context.Context, id string, members []string) (*model.Group, []*model.User, error)
 }
@@ -55,25 +56,35 @@ func (g *groupUseCase) CreateGroup(c context.Context, name string, owner string,
 }
 
 // GetGroupById implements GroupUseCase.
-func (g *groupUseCase) GetGroupById(c context.Context, id string) (*model.Group, []*model.User, error) {
+func (g *groupUseCase) GetGroupById(c context.Context, id string) (*model.Group, error) {
 	group, err := g.groupRepository.GetGroupById(c, id)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
+	}
+
+	return group, nil
+}
+
+// GetMembers implements GroupUseCase.
+func (g *groupUseCase) GetMembers(c context.Context, id string) ([]*model.User, error) {
+	group, err := g.groupRepository.GetGroupById(c, id)
+	if err != nil {
+		return nil, err
 	}
 	groupUsers, err := g.groupUserRepository.GetGroupUserById(c, group.ID)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	users := make([]*model.User, 0)
 	for _, groupUser := range groupUsers {
 		user, err := g.userRepository.GetUserByUid(c, groupUser.UserID)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		users = append(users, user)
 	}
 
-	return group, users, nil
+	return users, nil
 }
 
 // GetGroups implements GroupUseCase.


### PR DESCRIPTION
グループに所属するメンバーを
`{"members" : []}`
で返却するエンドポイントGET /groups/{groupId}/members を実装しました。
また、GET /groups/{groupId}のレスポンスから`"users" : []`を削除しました。

close #131 