### PR TITLE
フレンドが取得できない

### DIFF
--- a/pkg/interface/response/user.go
+++ b/pkg/interface/response/user.go
@@ -29,5 +29,5 @@ type UserStatus struct {
 }
 
 type Users struct {
-	Users []*model.User `json:"usrs"`
+	Users []*model.User `json:"users"`
 }


### PR DESCRIPTION
レスポンス用の構造体フィールのjosnタグが`usrs`になっていたことが原因でした。
当該のjosnタグを`users`に修正したました。

close #142 