### PR TITLE
フレンド削除機能の不具合を修正

### DIFF
--- a/pkg/interface/api/handler/user.go
+++ b/pkg/interface/api/handler/user.go
@@ -156,7 +156,7 @@ func (u *userHandler) HandlerFriendRequest(c echo.Context) error {
 func (u *userHandler) HandleDeleteFriend(c echo.Context) error {
 	errResponse := new(response.Error)
 	userID := c.Get("uid").(string)
-	friendUserID := c.Param("userID")
+	friendUserID := c.Param("userId")
 
 	err := u.useCase.DeleteFriend(c.Request().Context(), userID, friendUserID)
 	if err != nil {


### PR DESCRIPTION
closed #225 
ハンドラー関数HandleDeleteFriend()のパスパラメータのkey値がuserIDになっていたため、userIdに修正